### PR TITLE
Fix print paging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires-python = ">=3.14"
 dependencies = [
     "flask>=3.1.2",
     "pytest>=8.0.0",
+    "playwright>=1.54.0",
+    "pypdf>=5.9.0",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/parse_junit.sh
+++ b/scripts/parse_junit.sh
@@ -6,6 +6,11 @@
 FILE_PATH="${1:-results.xml}"
 LABEL="${2:-Tests}"
 
+sum_attr() {
+    local attr_name="$1"
+    grep -o "${attr_name}=\"[0-9]\+\"" "$FILE_PATH" | sed 's/[^0-9]//g' | awk '{s+=$1} END {print s+0}'
+}
+
 if [ ! -f "$FILE_PATH" ]; then
     echo "$LABEL: 0 passed, 0 failures, 0 errors (result file not found)"
     exit 1
@@ -15,32 +20,41 @@ fi
 # Note: Node.js 20 JUnit reporter might NOT have attributes in <testsuites> or <testsuite>
 # so we count tags as in parse_junit.js if attributes are missing or 0.
 
-# 1. Try to get summary from attributes (common in pytest)
-# We look for the first <testsuite> or <testsuites> that has tests="..."
-TOTAL_TESTS=$(grep -o 'tests="[0-9]\+"' "$FILE_PATH" | head -1 | sed 's/[^0-9]//g' || echo 0)
-FAILURES=$(grep -o 'failures="[0-9]\+"' "$FILE_PATH" | head -1 | sed 's/[^0-9]//g' || echo 0)
-ERRORS=$(grep -o 'errors="[0-9]\+"' "$FILE_PATH" | head -1 | sed 's/[^0-9]//g' || echo 0)
+# 1. Try to get summary from attributes (common in pytest / junit producers)
+# We sum all suite-level attributes across the file for robustness.
+TOTAL_TESTS=$(sum_attr "tests")
+FAILURES=$(sum_attr "failures")
+ERRORS=$(sum_attr "errors")
+SKIPPED=$(sum_attr "skipped")
+DISABLED=$(sum_attr "disabled")
+IGNORED=$(sum_attr "ignored")
 
 # 2. If TOTAL_TESTS is 0 or empty, it might be the Node.js format where we must count tags
 if [ -z "$TOTAL_TESTS" ] || [ "$TOTAL_TESTS" -eq 0 ]; then
     # Sanitize XML: remove attributes to avoid matching tags inside strings (like failure messages)
-    # Then count <testcase>, <failure>, <error>
+    # Then count <testcase>, <failure>, <error>, <skipped>, <disabled>, <ignored>
     # Note: this is a bit rough in shell compared to JS regex, but should work for most JUnit XMLs
     SANITISED=$(sed 's/[a-zA-Z0-9-]\+=\"[^\"]*\"//g' "$FILE_PATH")
     TOTAL_TESTS=$(echo "$SANITISED" | grep -o '<testcase' | wc -l)
     FAILURES=$(echo "$SANITISED" | grep -o '<failure' | wc -l)
     ERRORS=$(echo "$SANITISED" | grep -o '<error' | wc -l)
+    SKIPPED=$(echo "$SANITISED" | grep -o '<skipped' | wc -l)
+    DISABLED=$(echo "$SANITISED" | grep -o '<disabled' | wc -l)
+    IGNORED=$(echo "$SANITISED" | grep -o '<ignored' | wc -l)
 fi
 
 # Ensure they are numeric
 TOTAL_TESTS=${TOTAL_TESTS:-0}
 FAILURES=${FAILURES:-0}
 ERRORS=${ERRORS:-0}
+SKIPPED=${SKIPPED:-0}
+DISABLED=${DISABLED:-0}
+IGNORED=${IGNORED:-0}
 
-PASSED=$((TOTAL_TESTS - FAILURES - ERRORS))
+PASSED=$((TOTAL_TESTS - FAILURES - ERRORS - SKIPPED - DISABLED - IGNORED))
 if [ $PASSED -lt 0 ]; then PASSED=0; fi
 
-SUMMARY="$LABEL: $PASSED passed, $FAILURES failures, $ERRORS errors"
+SUMMARY="$LABEL: $PASSED passed, $FAILURES failures, $ERRORS errors, $SKIPPED skipped, $DISABLED disabled, $IGNORED ignored"
 echo "$SUMMARY"
 
 if [ "$PASSED" -eq 0 ] || [ "$FAILURES" -gt 0 ] || [ "$ERRORS" -gt 0 ]; then

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -108,9 +108,24 @@
 
 /* Print Styles */
 @media print {
+    @page {
+        margin: 0.35in;
+    }
+
     /* Hide non-printable elements */
     .navbar, .btn, .btn-group, .dropdown, .search-container, .edit-btn-container, .update-indicator-btn, .navbar-version {
         display: none !important;
+    }
+
+    .container > .d-flex.flex-wrap.gap-2.align-items-center.mb-3 {
+        display: none !important;
+    }
+
+    .container > h1 {
+        display: block !important;
+        margin: 0 0 0.3rem 0 !important;
+        font-size: 1.1rem !important;
+        line-height: 1.2 !important;
     }
 
     /* Force Grid View visibility and hide List View */
@@ -119,6 +134,8 @@
     }
     #gridView {
         display: block !important;
+        margin: 0 !important;
+        padding: 0 !important;
     }
 
     /* Reset container and body for print */
@@ -133,46 +150,90 @@
         max-width: 100% !important;
         width: 100% !important;
         margin: 0 !important;
-        padding: 0 !important;
+        padding: 0 0.08in !important;
     }
 
     /* Grid adjustments for print */
     #devicesGrid {
-        display: flex !important;
-        flex-wrap: wrap !important;
-        row-gap: 0.5rem !important;
-        column-gap: 0.5rem !important;
+        display: block !important;
+    }
+
+    .print-page {
+        display: grid !important;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        --bs-gutter-x: 0 !important;
+        --bs-gutter-y: 0 !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        align-content: start;
+        min-height: 0 !important;
+        row-gap: 0.2rem !important;
+        column-gap: 0.2rem !important;
+        break-before: auto;
+        page-break-before: auto;
+        break-inside: avoid;
+        page-break-inside: avoid;
+        break-after: page;
+        page-break-after: always;
+    }
+
+    .print-page:first-child {
+        break-before: avoid-page;
+        page-break-before: avoid;
+    }
+
+    .print-page:last-child {
+        break-after: auto;
+        page-break-after: auto;
     }
 
     .device-card-col {
-        width: 23% !important; /* Approximately 4 columns with some margin */
+        width: auto !important;
+        min-width: 0;
+        max-width: none !important;
+        box-sizing: border-box;
         page-break-inside: avoid;
         break-inside: avoid;
-        margin-bottom: 0.5rem;
-        padding: 0 0.25rem !important;
+        margin-bottom: 0 !important;
+        padding: 0 !important;
     }
 
     .card {
         border: 1px solid #dee2e6 !important;
         box-shadow: none !important;
         background-color: white !important;
+        margin: 0 !important;
     }
 
     .card-body {
-        padding: 0.5rem !important;
+        padding: 0.2rem !important;
+    }
+
+    .card-body .mb-3.mt-2 {
+        margin-top: 0 !important;
+        margin-bottom: 0.25rem !important;
     }
 
     .card-title {
-        font-size: 0.8rem !important;
+        font-size: 0.7rem !important;
+        line-height: 1.1 !important;
         color: black !important;
-        margin-top: 0.25rem !important;
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
     }
 
     /* Ensure QR codes are visible and correctly sized */
+    .qr-preview-container,
+    .qr-placeholder {
+        max-width: 110px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
     .qr-placeholder canvas {
         box-shadow: none !important;
         border: 1px solid #eee;
-        width: 100% !important;
-        height: auto !important;
+        width: 110px !important;
+        height: 110px !important;
     }
 }

--- a/src/templates/matter.html
+++ b/src/templates/matter.html
@@ -87,8 +87,11 @@
         </div>
 
         <div id="gridView" class="d-none">
-            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4" id="devicesGrid">
+            <div id="devicesGrid">
                 {% for row in data %}
+                {% if loop.index0 % 16 == 0 %}
+                <div class="print-page row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
+                {% endif %}
                 <div class="col device-card-col" data-mac="{{ row['MAC'] }}">
                     <div class="card h-100 shadow-sm border-0 bg-light-subtle">
                         <div class="edit-btn-container">
@@ -112,6 +115,9 @@
                         </div>
                     </div>
                 </div>
+                {% if loop.index % 16 == 0 or loop.last %}
+                </div>
+                {% endif %}
                 {% endfor %}
             </div>
         </div>

--- a/src/templates/matter.html
+++ b/src/templates/matter.html
@@ -112,6 +112,9 @@
                                 {% endif %}
                             </div>
                             <h5 class="card-title text-truncate mb-1" title="{{ row['Description'] }}">{{ row['Description'] }}</h5>
+                            {% if row['Pairing Code'] %}
+                            <p class="small text-body-secondary mb-0 pairing-code">{{ row['Pairing Code'] }}</p>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,30 +3,60 @@ import os
 import tempfile
 from app import app
 
-@pytest.fixture
-def client():
-    # Setup: use a temporary file for the data
+
+def _write(csv_content):
     fd, temp_path = tempfile.mkstemp(suffix='.csv')
     os.close(fd)
-    
-    # Pre-populate with test data
-    with open(temp_path, 'w', encoding='utf-8') as f:
-        f.write("Product,Type,MAC,Pairing Code,Description,QR\n")
-        f.write("Tapo S505D,Switch,00:11:22:33:44:55,12345678901,Bedroom Switch,test-qr-data\n")
 
-    # Set environment variable so app uses this file
+    with open(temp_path, 'w', encoding='utf-8', newline='') as f:
+        if isinstance(csv_content, str):
+            f.write(csv_content)
+        elif isinstance(csv_content, (list, tuple)):
+            f.writelines(
+                f"{str(line).rstrip(chr(10))}\n" for line in csv_content
+            )
+        else:
+            raise TypeError(
+                'csv_content must be a string or an array of rows'
+            )
+
+    return temp_path
+
+@pytest.fixture
+def matter_data_path():
+    """
+    Factory fixture that creates a temporary CSV, points MATTER_DATA_PATH to it,
+    and restores environment on teardown.
+    """
     old_path = os.getenv('MATTER_DATA_PATH')
-    os.environ['MATTER_DATA_PATH'] = temp_path
+    created_paths = []
+
+    def _create(csv_content):
+        temp_path = _write(csv_content)
+        created_paths.append(temp_path)
+        os.environ['MATTER_DATA_PATH'] = temp_path
+        return temp_path
+
+    yield _create
+
+    if old_path is None:
+        os.environ.pop('MATTER_DATA_PATH', None)
+    else:
+        os.environ['MATTER_DATA_PATH'] = old_path
+
+    for path in created_paths:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+@pytest.fixture
+def client(matter_data_path):
+    # Setup: use a temporary file for the data
+    matter_data_path(
+        "Product,Type,MAC,Pairing Code,Description,QR\n"
+        "Tapo S505D,Switch,00:11:22:33:44:55,12345678901,Bedroom Switch,test-qr-data\n"
+    )
     
     app.testing = True
     with app.test_client() as client:
         yield client
-
-    # Teardown
-    if old_path is None:
-        del os.environ['MATTER_DATA_PATH']
-    else:
-        os.environ['MATTER_DATA_PATH'] = old_path
-    
-    if os.path.exists(temp_path):
-        os.remove(temp_path)

--- a/tests/js/extract_grid_layout_from_dom.js
+++ b/tests/js/extract_grid_layout_from_dom.js
@@ -1,0 +1,30 @@
+() => {
+    const printPages = Array.from(document.querySelectorAll('.print-page'));
+    const yTolerance = 8;
+
+    if (!printPages.length) {
+        return [];
+    }
+
+    return printPages.map((printPage) => {
+        const pageItems = Array.from(printPage.querySelectorAll('.device-card-col'))
+            .map((el) => {
+                const r = el.getBoundingClientRect();
+                return { top: r.top, left: r.left };
+            })
+            .sort((a, b) => a.top - b.top || a.left - b.left);
+
+        const rows = [];
+
+        for (const item of pageItems) {
+            let row = rows.find((r) => Math.abs(r.y - item.top) <= yTolerance);
+            if (!row) {
+                row = { y: item.top, xs: [] };
+                rows.push(row);
+            }
+            row.xs.push(item.left);
+        }
+
+        return rows.map((row) => row.xs.length);
+    });
+}

--- a/tests/js/extract_physical_print_pages_from_dom.js
+++ b/tests/js/extract_physical_print_pages_from_dom.js
@@ -1,0 +1,51 @@
+() => {
+    const allItems = Array.from(document.querySelectorAll('.print-page .device-card-col'));
+    if (!allItems.length) {
+        return [];
+    }
+
+    const yTolerance = 8;
+    const inchPx = 96;
+    const pageHeightPx = 11 * inchPx;
+    const pageMarginPx = 0.35 * inchPx;
+    const printableHeightPx = pageHeightPx - (2 * pageMarginPx);
+
+    const buckets = new Map();
+
+    for (const el of allItems) {
+        const r = el.getBoundingClientRect();
+        const physicalPageIndex = Math.max(0, Math.floor(r.top / printableHeightPx));
+
+        if (!buckets.has(physicalPageIndex)) {
+            buckets.set(physicalPageIndex, []);
+        }
+        buckets.get(physicalPageIndex).push({ top: r.top, left: r.left });
+    }
+
+    const maxPageIndex = Math.max(...Array.from(buckets.keys()));
+    const result = [];
+
+    for (let pageIndex = 0; pageIndex <= maxPageIndex; pageIndex++) {
+        const items = (buckets.get(pageIndex) || [])
+            .slice()
+            .sort((a, b) => a.top - b.top || a.left - b.left);
+
+        if (!items.length) {
+            result.push([]);
+            continue;
+        }
+
+        const rows = [];
+        for (const item of items) {
+            let row = rows.find((r) => Math.abs(r.y - item.top) <= yTolerance);
+            if (!row) {
+                row = { y: item.top, xs: [] };
+                rows.push(row);
+            }
+            row.xs.push(item.left);
+        }
+        result.push(rows.map((row) => row.xs.length));
+    }
+
+    return result;
+}

--- a/tests/test_common_reporter_logic.py
+++ b/tests/test_common_reporter_logic.py
@@ -37,19 +37,25 @@ def run_parser(xml_content, label="Tests"):
 
 @pytest.mark.parametrize("name, xml, label, expected_output, expected_status", [
     # Python (pytest) format: attributes in <testsuite>
-    ("Pytest: All passed", '<testsuite tests="2" failures="0" errors="0"></testsuite>', "Python", "Python: 2 passed, 0 failures, 0 errors", 0),
-    ("Pytest: Some failures", '<testsuite tests="2" failures="1" errors="0"></testsuite>', "Python", "Python: 1 passed, 1 failures, 0 errors", 1),
+    ("Pytest: All passed", '<testsuite tests="2" failures="0" errors="0"></testsuite>', "Python", "Python: 2 passed, 0 failures, 0 errors, 0 skipped, 0 disabled, 0 ignored", 0),
+    ("Pytest: Some failures", '<testsuite tests="2" failures="1" errors="0"></testsuite>', "Python", "Python: 1 passed, 1 failures, 0 errors, 0 skipped, 0 disabled, 0 ignored", 1),
     
     # Node.js format: count tags
-    ("Node.js: All passed", '<testsuites><testcase name="t1" /><testcase name="t2" /></testsuites>', "JS", "JS: 2 passed, 0 failures, 0 errors", 0),
-    ("Node.js: Some failures", '<testsuites><testcase name="t1" /><testcase name="t2"><failure message="fail" /></testcase></testsuites>', "JS", "JS: 1 passed, 1 failures, 0 errors", 1),
-    ("Node.js: Some errors", '<testsuites><testcase name="t1" /><testcase name="t2"><error message="err" /></testcase></testsuites>', "JS", "JS: 1 passed, 0 failures, 1 errors", 1),
+    ("Node.js: All passed", '<testsuites><testcase name="t1" /><testcase name="t2" /></testsuites>', "JS", "JS: 2 passed, 0 failures, 0 errors, 0 skipped, 0 disabled, 0 ignored", 0),
+    ("Node.js: Some failures", '<testsuites><testcase name="t1" /><testcase name="t2"><failure message="fail" /></testcase></testsuites>', "JS", "JS: 1 passed, 1 failures, 0 errors, 0 skipped, 0 disabled, 0 ignored", 1),
+    ("Node.js: Some errors", '<testsuites><testcase name="t1" /><testcase name="t2"><error message="err" /></testcase></testsuites>', "JS", "JS: 1 passed, 0 failures, 1 errors, 0 skipped, 0 disabled, 0 ignored", 1),
+    ("Node.js: Some skipped", '<testsuites><testcase name="t1" /><testcase name="t2"><skipped /></testcase></testsuites>', "JS", "JS: 1 passed, 0 failures, 0 errors, 1 skipped, 0 disabled, 0 ignored", 0),
+    ("Node.js: Some disabled", '<testsuites><testcase name="t1" /><testcase name="t2"><disabled /></testcase></testsuites>', "JS", "JS: 1 passed, 0 failures, 0 errors, 0 skipped, 1 disabled, 0 ignored", 0),
+    ("Node.js: Some ignored", '<testsuites><testcase name="t1" /><testcase name="t2"><ignored /></testcase></testsuites>', "JS", "JS: 1 passed, 0 failures, 0 errors, 0 skipped, 0 disabled, 1 ignored", 0),
+
+    # Aggregation across multiple suites with attributes
+    ("Multiple suites: attribute aggregation", '<testsuites><testsuite tests="2" failures="0" errors="0" skipped="1" disabled="0" ignored="0"></testsuite><testsuite tests="3" failures="1" errors="0" skipped="0" disabled="1" ignored="1"></testsuite></testsuites>', "JUnit", "JUnit: 1 passed, 1 failures, 0 errors, 1 skipped, 1 disabled, 1 ignored", 1),
     
     # Edge cases
     ("Missing file", None, "Tests", "0 passed, 0 failures, 0 errors (result file not found)", 1),
-    ("Empty file", "", "Tests", "Tests: 0 passed, 0 failures, 0 errors", 1),
-    ("Zero tests", '<testsuite tests="0" failures="0" errors="0"></testsuite>', "Tests", "Tests: 0 passed, 0 failures, 0 errors", 1),
-    ("Failure with message containing tags", '<testsuites><testcase name="t1"><failure message="Expected <failure> but got <something else>" /></testcase></testsuites>', "JS", "JS: 0 passed, 1 failures, 0 errors", 1),
+    ("Empty file", "", "Tests", "Tests: 0 passed, 0 failures, 0 errors, 0 skipped, 0 disabled, 0 ignored", 1),
+    ("Zero tests", '<testsuite tests="0" failures="0" errors="0"></testsuite>', "Tests", "Tests: 0 passed, 0 failures, 0 errors, 0 skipped, 0 disabled, 0 ignored", 1),
+    ("Failure with message containing tags", '<testsuites><testcase name="t1"><failure message="Expected <failure> but got <something else>" /></testcase></testsuites>', "JS", "JS: 0 passed, 1 failures, 0 errors, 0 skipped, 0 disabled, 0 ignored", 1),
 ])
 def test_parse_junit_sh(name, xml, label, expected_output, expected_status):
     output, status = run_parser(xml, label)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,46 +1,17 @@
 import pytest
-import os
 import csv
-import tempfile
 
-@pytest.fixture
-def client_with_data(client):
-    # Create a temporary CSV file
-    fd, temp_path = tempfile.mkstemp(suffix='.csv')
-    os.close(fd)
-    
-    # Set up some initial data
-    headers = ['Product', 'Type', 'MAC', 'Pairing Code', 'Description', 'QR']
-    initial_data = [
-        {'Product': 'Device1', 'Type': 'Type1', 'MAC': '11:22:33:44:55:66', 'Pairing Code': '123-456', 'Description': 'Desc1', 'QR': 'QR1'},
-        {'Product': 'Device2', 'Type': 'Type2', 'MAC': 'AA:BB:CC:DD:EE:FF', 'Pairing Code': '789-012', 'Description': 'Desc2', 'QR': 'QR2'}
-    ]
-    
-    with open(temp_path, 'w', newline='', encoding='utf-8') as f:
-        writer = csv.DictWriter(f, fieldnames=headers)
-        writer.writeheader()
-        writer.writerows(initial_data)
-    
-    # Override the data path
-    old_data_path = os.environ.get('MATTER_DATA_PATH')
-    os.environ['MATTER_DATA_PATH'] = temp_path
+test_data = ['Product,Type,MAC,Pairing Code,Description,QR',
+             'Device1,Type1,11:22:33:44:55:66,123-456,Desc1,QR1',
+             'Device2,Type2,AA:BB:CC:DD:EE:FF,123-456,Desc2,QR2',
+]
 
-    yield client, temp_path
+def test_delete_device_success(client, matter_data_path):
+    temp_path = matter_data_path(test_data)
 
-    # Cleanup
-    if os.path.exists(temp_path):
-        os.remove(temp_path)
-    if old_data_path:
-        os.environ['MATTER_DATA_PATH'] = old_data_path
-    else:
-        if 'MATTER_DATA_PATH' in os.environ:
-            del os.environ['MATTER_DATA_PATH']
-
-def test_delete_device_success(client_with_data):
-    c, temp_path = client_with_data
     # Delete Device1
     mac_to_delete = '11:22:33:44:55:66'
-    response = c.delete(f'/matter/{mac_to_delete}')
+    response = client.delete(f'/matter/{mac_to_delete}')
     assert response.status_code == 200
     assert response.get_json() == {"success": True}
     
@@ -51,11 +22,12 @@ def test_delete_device_success(client_with_data):
         assert len(data) == 1
         assert data[0]['MAC'] == 'AA:BB:CC:DD:EE:FF'
 
-def test_delete_device_not_found(client_with_data):
-    c, temp_path = client_with_data
+def test_delete_device_not_found(client, matter_data_path):
+    temp_path = matter_data_path(test_data)
+
     # Try to delete non-existent device
     mac_to_delete = '00:00:00:00:00:00'
-    response = c.delete(f'/matter/{mac_to_delete}')
+    response = client.delete(f'/matter/{mac_to_delete}')
     assert response.status_code == 404
     assert "error" in response.get_json()
     

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1,72 +1,43 @@
-import pytest
-import os
-import csv
-import io
+from conftest import _write
+
+test_data = [
+    'Product,Type,MAC,Pairing Code,Description,QR',
+    'Test Device,Test Type,AA:BB:CC:DD:EE:FF,123-45-678,Test Desc,',
+]
+
+csv_data = [
+    'Product,Type,MAC,Pairing Code,Description,QR',
+    'New Device,Type 2,11:22:33:44:55:66,987-65-432,New Desc,',
+    'Duplicate Device,Type 1,AA:BB:CC:DD:EE:FF,123-45-678,Existing,'
+]
 
 
-@pytest.fixture
-def client_with_test_data(client):
-    # Backup original data path
-    old_data_path = os.environ.get('MATTER_DATA_PATH')
-    test_data_path = os.path.join(os.getcwd(), 'data', 'test_matter.csv')
-    os.environ['MATTER_DATA_PATH'] = test_data_path
-    
-    # Create a test CSV
-    with open(test_data_path, 'w', encoding='utf-8', newline='') as f:
-        writer = csv.DictWriter(f, fieldnames=['Product', 'Type', 'MAC', 'Pairing Code', 'Description', 'QR'])
-        writer.writeheader()
-        writer.writerow({
-            'Product': 'Test Device',
-            'Type': 'Test Type',
-            'MAC': 'AA:BB:CC:DD:EE:FF',
-            'Pairing Code': '123-45-678',
-            'Description': 'Test Desc',
-            'QR': ''
-        })
+def test_export(client, matter_data_path):
+    matter_data_path(test_data)
 
-    yield client, test_data_path
-
-    if os.path.exists(test_data_path):
-        os.remove(test_data_path)
-    # Restore environment variable
-    if old_data_path:
-        os.environ['MATTER_DATA_PATH'] = old_data_path
-    else:
-        if 'MATTER_DATA_PATH' in os.environ:
-            del os.environ['MATTER_DATA_PATH']
-
-def test_export(client_with_test_data):
-    c, _ = client_with_test_data
-    response = c.get('/matter/export')
+    response = client.get('/matter/export')
     assert response.status_code == 200
     assert response.mimetype == 'text/csv'
     assert b'AA:BB:CC:DD:EE:FF' in response.data
 
-def test_import(client_with_test_data):
-    c, _ = client_with_test_data
-    # Create a CSV to import
-    csv_data = [
-        ['Product', 'Type', 'MAC', 'Pairing Code', 'Description', 'QR'],
-        ['New Device', 'Type 2', '11:22:33:44:55:66', '987-65-432', 'New Desc', ''],
-        ['Duplicate Device', 'Type 1', 'AA:BB:CC:DD:EE:FF', '123-45-678', 'Existing', '']
-    ]
-    
-    output = io.StringIO()
-    writer = csv.writer(output)
-    writer.writerows(csv_data)
-    
-    data = {
-        'file': (io.BytesIO(output.getvalue().encode('utf-8')), 'test.csv')
-    }
-    
-    response = c.post('/matter/import', data=data, content_type='multipart/form-data')
+def test_import(client, matter_data_path):
+    matter_data_path(test_data)
+    temp_csv_file = _write(csv_data)
+
+    with open(temp_csv_file, 'rb') as csv_file:
+        data = {
+            'file': (csv_file, 'test.csv')
+        }
+
+        response = client.post('/matter/import', data=data, content_type='multipart/form-data')
+
     assert response.status_code == 200
     json_data = response.get_json()
     assert json_data['success']
     assert json_data['added_count'] == 1 # Only one should be added due to de-duplication
     
     # Verify content
-    response = c.get('/matter')
+    response = client.get('/matter')
     data = response.get_json()
     macs = [item['MAC'] for item in data]
     assert '11:22:33:44:55:66' in macs

--- a/tests/test_print_view_pagination.py
+++ b/tests/test_print_view_pagination.py
@@ -1,0 +1,55 @@
+from html.parser import HTMLParser
+
+
+class PrintPageParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._print_page_depth = 0
+        self._print_page_stack = []
+        self.page_card_counts = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "div":
+            return
+
+        attrs_dict = dict(attrs)
+        classes = set(attrs_dict.get("class", "").split())
+        is_print_page = "print-page" in classes
+        self._print_page_stack.append(is_print_page)
+
+        if is_print_page:
+            self._print_page_depth += 1
+            self.page_card_counts.append(0)
+
+        if self._print_page_depth > 0 and "device-card-col" in classes:
+            self.page_card_counts[-1] += 1
+
+    def handle_endtag(self, tag):
+        if tag != "div" or not self._print_page_stack:
+            return
+
+        was_print_page = self._print_page_stack.pop()
+        if was_print_page:
+            self._print_page_depth -= 1
+
+
+def _build_test_csv(total_rows):
+    header = "Product,Type,MAC,Pairing Code,Description,QR\n"
+    rows = [header]
+    for i in range(total_rows):
+        rows.append(
+            f"Product {i},Switch,00:11:22:33:44:{i:02X},{10000000000 + i},Device {i},test-qr-{i}\n"
+        )
+    return "".join(rows)
+
+
+def test_print_view_renders_three_pages_for_36_cards(client, matter_data_path):
+    path = matter_data_path(_build_test_csv(36))
+
+    response = client.get("/")
+    assert response.status_code == 200
+
+    parser = PrintPageParser()
+    parser.feed(response.data.decode("utf-8"))
+
+    assert parser.page_card_counts == [16, 16, 4]

--- a/tests/test_print_view_playwright.py
+++ b/tests/test_print_view_playwright.py
@@ -1,0 +1,92 @@
+import contextlib
+import re
+import os
+import threading
+import tempfile
+from pathlib import Path
+
+import pypdf
+import pytest
+from werkzeug.serving import make_server
+
+from app import app
+
+
+_JS_DIR = Path(__file__).parent / "js"
+
+
+def _load_js(script_name):
+    return (_JS_DIR / script_name).read_text(encoding="utf-8")
+
+
+def _build_test_csv(total_rows):
+    header = "Product,Type,MAC,Pairing Code,Description,QR\n"
+    rows = [header]
+    for i in range(total_rows):
+        rows.append(
+            f"Product {i},Switch,00:11:22:33:44:{i:02X},{10000000000 + i},Device {i},test-qr-{i}\n"
+        )
+    return "".join(rows)
+
+
+@pytest.fixture
+def live_server(matter_data_path):
+    matter_data_path(_build_test_csv(36))
+    server = make_server("127.0.0.1", 0, app)
+    port = server.socket.getsockname()[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=3)
+
+
+def _extract_grid_layout_from_dom(page):
+    return page.evaluate(_load_js("extract_grid_layout_from_dom.js"))
+
+
+def _extract_physical_print_pages_from_dom(page):
+    return page.evaluate(_load_js("extract_physical_print_pages_from_dom.js"))
+
+
+def _extract_pdf_page_device_counts(pdf_path):
+    reader = pypdf.PdfReader(pdf_path)
+    device_counts = []
+
+    for pdf_page in reader.pages:
+        text = pdf_page.extract_text() or ""
+        device_counts.append(len(re.findall(r"\bDevice\s+\d+\b", text)))
+
+    return device_counts
+
+
+def test_print_view_has_4x4_grid_layout_for_full_pages(live_server):
+    playwright_sync_api = pytest.importorskip("playwright.sync_api")
+
+    with playwright_sync_api.sync_playwright() as playwright:
+        try:
+            browser = playwright.chromium.launch(channel="msedge")
+        except Exception as exc:  # pragma: no cover - environment dependent
+            pytest.skip(f"Playwright browser is not available: {exc}")
+
+        with contextlib.closing(browser):
+            page = browser.new_page()
+            page.goto(f"{live_server}/", wait_until="networkidle")
+            page.evaluate("window.setView('grid')")
+            page.wait_for_timeout(500)
+            page.emulate_media(media="print")
+            layout = _extract_grid_layout_from_dom(page)
+            fd, pdf_path = tempfile.mkstemp(suffix=".pdf")
+            os.close(fd)
+            try:
+                page.pdf(path=pdf_path, print_background=True, format="Letter")
+                physical_page_device_counts = _extract_pdf_page_device_counts(pdf_path)
+            finally:
+                if os.path.exists(pdf_path):
+                    os.remove(pdf_path)
+
+    assert layout == [[4, 4, 4, 4], [4, 4, 4, 4], [4]]
+    assert physical_page_device_counts, "Expected at least one physical print page"
+    assert physical_page_device_counts == [16, 16, 4]


### PR DESCRIPTION
Ensure that QR codes are rendered in a 4x4 grid on each page. Fix rendering, which was broken on page 2+.
Add playright tests, because other attempts to confirm rendering were not capturing the failure.